### PR TITLE
Throws error when no route is defined; Throws error when can not find constant

### DIFF
--- a/lib/cthulhu.rb
+++ b/lib/cthulhu.rb
@@ -3,11 +3,11 @@ require 'json'
 require 'logger'
 
 module Cthulhu
-  @@routes = nil
+  @@routes = {}
   @@channel = nil
 
   def self.delete_routes
-    @@routes = nil
+    @@routes = {}
   end
   def self.routes &block
     if block_given?
@@ -16,7 +16,6 @@ module Cthulhu
     @@routes
   end
   def self.route(subject:, to: )
-    @@routes ||= {}
     @@routes[subject] = to
   end
 

--- a/lib/cthulhu/application.rb
+++ b/lib/cthulhu/application.rb
@@ -95,7 +95,7 @@ module Cthulhu
       method_name = properties.headers["action"].downcase
       class_name = Cthulhu.routes[properties.headers["subject"]]
 
-      if !( Cthulhu.routes || class_name || Object.const_defined?(class_name) )
+      if !class_name || !Object.const_defined?(class_name)
         return false
       end
 

--- a/lib/cthulhu/application.rb
+++ b/lib/cthulhu/application.rb
@@ -92,13 +92,15 @@ module Cthulhu
     end
 
     def self.handler_exists?(properties, message)
-      headers = properties.headers
-      class_name = Cthulhu.routes[headers["subject"]]
-      return false unless Object.const_defined?(class_name)
-      method_name = headers["action"].downcase
+      method_name = properties.headers["action"].downcase
+      class_name = Cthulhu.routes[properties.headers["subject"]]
+
+      if !( Cthulhu.routes || class_name || Object.const_defined?(class_name) )
+        return false
+      end
+
       klass = Object.const_get class_name
-      return false unless klass.method_defined?(method_name)
-      return class_name
+      return klass.method_defined?(method_name)
     end
 
     def self.call_handler_for(properties, message)

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -83,18 +83,19 @@ describe Cthulhu::Application do
     expect(subject.valid?(properties, message)).to be == false
   end
 
-  it '#handler_exists?' do
-
-    expect(subject.handler_exists?(properties, message)).to be == "TestHandler"
-
-    p = {
-      headers: {"subject" => "fail", "action" => "ack_test", "from" => "app"},
-      timestamp: Time.now,
-      message_id: '374892374823748923748'
-    }
-    properties = Bunny::MessageProperties.new(p)
-    expect(subject.handler_exists?(properties, message)).to be == false
-
+  describe '#handler_exists?' do
+    it 'returns true when the route exists' do
+      expect(subject.handler_exists?(properties, message)).to be == true
+    end
+    it 'returns false when the route is invalid' do
+      p = {
+        headers: {"subject" => "fail", "action" => "ack_test", "from" => "app"},
+        timestamp: Time.now,
+        message_id: '374892374823748923748'
+      }
+      properties = Bunny::MessageProperties.new(p)
+      expect(subject.handler_exists?(properties, message)).to be == false
+    end
   end
 
   it '#call_handler_for' do

--- a/spec/cthulhu_spec.rb
+++ b/spec/cthulhu_spec.rb
@@ -31,7 +31,7 @@ describe Cthulhu do
 
   it 'delete routes' do
     subject.delete_routes
-    expect(subject.routes).to be_nil
+    expect(subject.routes.empty?).to eq(true)
   end
 
 end


### PR DESCRIPTION
When an app is just broadcasting and zero routes are defined, It throughs an error for every oncoming message.

Also, if a message comes in and there is no route for that subject (i.e. no class defined to handle that subject), `Object.const_defined?` throws a type conversion error because we are passing in `nil`. 