### PR TITLE
Support for rails autoloading classes

### DIFF
--- a/lib/cthulhu/railtie.rb
+++ b/lib/cthulhu/railtie.rb
@@ -2,7 +2,7 @@ require 'cthulhu'
 require 'rails'
 
 module Cthulhu
-  class Railtie < Rails::Railtie
+  class Railtie < ::Rails::Railtie
 
     initializer "cthulhu_notify.active_record" do |app|
       ActiveSupport.on_load :active_record do


### PR DESCRIPTION
Rewrite of the `handler_exists?` method supports rails autoloading.

We call `Object.const_get` on every method call, instead of calling `Object.const_defined?`. By calling `Object.const_get` rails will try and autoload the class. If class is not found, wether we are in plain ruby or class is not defined, we recuse the error and return false. If the class is found, we continue as normal.

This change will keep existing behavior as well as support rails autoloading.