### PR TITLE
Add support for options attribute in the broadcast header

### DIFF
--- a/cthulhu.gemspec
+++ b/cthulhu.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'cthulhu'
-  s.version     = '0.4.0'
+  s.version     = '0.4.0.1'
   s.date        = '2016-05-20'
   s.summary     = "No life matter"
   s.description = "No description. Get over it."

--- a/lib/cthulhu/application.rb
+++ b/lib/cthulhu/application.rb
@@ -109,8 +109,8 @@ module Cthulhu
     end
     def self.parse(delivery_info, properties, payload)
       headers = properties.headers
-      # ignore messages sent by myself
-      # return "ignore!" if headers["from"] == Cthulhu::Application.name
+      options = headers["options"]
+
       message = JSON.parse payload, object_class: OpenStruct
       return 'ignore!' unless valid?(properties, message)
 

--- a/lib/cthulhu/message.rb
+++ b/lib/cthulhu/message.rb
@@ -17,7 +17,8 @@ module Cthulhu
         headers: {
           from: Cthulhu::Application.name,
           subject: message[:subject],
-          action: message[:action]
+          action: message[:action],
+          options: message[:options]
         }
       }
       exchange.publish(payload, options)

--- a/lib/cthulhu/notifier.rb
+++ b/lib/cthulhu/notifier.rb
@@ -7,7 +7,7 @@ module Cthulhu
     module ClassMethods
       ACTION_MAP = { destroy: "after_destory", create: 'after_save', update: 'after_save' }
 
-      def cthulhu_notify(options)
+      def cthulhu_notify(options={})
         on = options.delete(:on)
         on = ACTION_MAP.keys if on.nil?
 
@@ -15,7 +15,7 @@ module Cthulhu
         on.each do |o|
           action = ACTION_MAP[o.to_sym]
           next if action.nil?
-          self.send( action, {|model| model.cthulhu_publish("#{o}ed", options)} )
+          self.send( action ) { |model| model.cthulhu_publish("#{o}ed", options) }
         end
       end
     end

--- a/lib/cthulhu/notifier.rb
+++ b/lib/cthulhu/notifier.rb
@@ -14,6 +14,7 @@ module Cthulhu
         include Cthulhu::Notifier::InstanceMethods
         on.each do |o|
           action = ACTION_MAP[o.to_sym]
+          next if action.nil?
           self.send( action, {|model| model.cthulhu_publish("#{o}ed", options)} )
         end
       end

--- a/lib/cthulhu/notifier.rb
+++ b/lib/cthulhu/notifier.rb
@@ -5,25 +5,23 @@ module Cthulhu
     end
 
     module ClassMethods
-      def cthulhu_notify(on: [])
+      ACTION_MAP = { destroy: "after_destory", create: 'after_save', update: 'after_save' }
+
+      def cthulhu_notify(options)
+        on = options.delete(:on)
+        on = ACTION_MAP.keys if on.nil?
+
         include Cthulhu::Notifier::InstanceMethods
-        if on.any?
-          on.each do |o|
-            after_destroy { |model| model.cthulhu_publish(action: "destroyed") } if o == :destroy
-            after_save { |model| model.cthulhu_publish(action: "created") } if o == :create
-            after_save { |model| model.cthulhu_publish(action: "updated") } if o == :update
-          end
-        else
-          after_destroy { |model| model.cthulhu_publish(action: "destroyed") }
-          after_save { |model| model.cthulhu_publish(action: "created") }
-          after_save { |model| model.cthulhu_publish(action: "updated") }
+        on.each do |o|
+          action = ACTION_MAP[o.to_sym]
+          self.send( action, {|model| model.cthulhu_publish("#{o}ed", options)} )
         end
       end
     end
 
     module InstanceMethods
-      def cthulhu_publish(action:)
-        Cthulhu.publish(subject: self.class.name, action: action, payload: self.attributes )
+      def cthulhu_publish(action, options)
+        Cthulhu.publish(subject: self.class.name, action: action, options: options, payload: self.attributes )
       end
     end
   end

--- a/template/Gemfile
+++ b/template/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'envyable'
-gem 'cthulhu', "~>0.4.0", git: "https://github.com/HealthWave/cthulhu.git"
+gem 'cthulhu', "~>0.4.0.1", git: "https://github.com/HealthWave/cthulhu.git"
 
 gem 'json'
 group :development do


### PR DESCRIPTION
Added an options header value when broadcasting an event. 

This will be useful in the feature as well as let up add back to functionality that we had previously (not responding to message that were generated by the current app) optional.
  